### PR TITLE
Fix babelrc to output lib.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,10 +7,9 @@
   ],
   "env": {
     "commonjs": {
-      "plugins": [
-        ["transform-es2015-modules-commonjs", {
-          "strict": false,
-          "allowTopLevelThis": true
+      "presets": [
+        ["env", {
+          "modules": "commonjs"
         }]
       ]
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "npm run clean && npm run build:es && npm run build:lib",
     "build:es": "BABEL_ENV=es babel src --out-dir es",
-    "build:lib": "BABEL_ENV= babel src --out-dir lib",
+    "build:lib": "BABEL_ENV=commonjs babel src --out-dir lib",
     "clean": "rimraf es && rimraf lib",
     "preversion": "npm run test",
     "test:only": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
     "chai": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,7 +549,7 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1, babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
   dependencies:


### PR DESCRIPTION
* Make `lib/` output actually CommonJS. Fixes #9 
* Remove need for separate `transform-es2015-modules-commonjs` dependency by just using a redefinition of the `env` plugin options.

/cc @aweary 