### PR TITLE
Update package.json to include the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
      "test": "lerna run test",
      "build": "lerna run build"
    },
+   "repository": {
+      "type": "git",
+      "url": "https://github.com/FormidableLabs/image-palette.git"
+    },
    "devDependencies": {
       "babel-cli": "^6.26.0",
       "babel-preset-env": "^1.6.0",

--- a/packages/image-palette-core/package.json
+++ b/packages/image-palette-core/package.json
@@ -16,6 +16,11 @@
     "test:only": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "test": "npm run build && npm run test:only"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/image-palette.git",
+    "directory": "packages/image-palette-core"
+  },
   "dependencies": {
     "color": "^2.0.0",
     "lodash.isequal": "^4.5.0",

--- a/packages/preact-image-palette/package.json
+++ b/packages/preact-image-palette/package.json
@@ -16,6 +16,11 @@
     "test:only": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "test": "npm run build && npm run test:only"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/image-palette.git",
+    "directory": "packages/preact-image-palette"
+  },
   "dependencies": {
     "image-palette-core": "^0.2.2"
   },

--- a/packages/react-image-palette/package.json
+++ b/packages/react-image-palette/package.json
@@ -16,6 +16,11 @@
     "test:only": "karma start --single-run --browsers ChromeHeadless ../../karma.conf.js",
     "test": "npm run build && npm run test:only"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FormidableLabs/image-palette.git",
+    "directory": "packages/react-image-palette"
+  },
   "dependencies": {
     "image-palette-core": "^0.2.2"
   },


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• image-palette-core
• preact-image-palette
• react-image-palette
• image-palette